### PR TITLE
Authenticate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,14 @@
         "lodash": "^4.17.10"
       }
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -319,6 +327,18 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      }
+    },
     "mpath": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
@@ -363,6 +383,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "parseurl": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,436 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "bcrypt": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-3.0.3.tgz",
+      "integrity": "sha512-4EuzUo6K790QC3uq/ogzy9w2Hc7XDIBoEndU5y7l7YaEAwQF8vyFqv6tC30+gOBZvyxk3F632xzKBQoLNz2pjg==",
+      "requires": {
+        "nan": "2.12.1",
+        "node-pre-gyp": "0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.12",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -460,6 +890,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "negotiator": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,11 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
       "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -103,6 +108,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -228,6 +241,48 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
+    "jsonwebtoken": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "requires": {
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kareem": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
@@ -242,6 +297,41 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.16.4",
+    "jsonwebtoken": "^8.4.0",
     "mongoose": "^5.4.1",
     "morgan": "^1.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.16.4",
-    "mongoose": "^5.4.1"
+    "mongoose": "^5.4.1",
+    "morgan": "^1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^3.0.3",
     "express": "^4.16.4",
     "jsonwebtoken": "^8.4.0",
     "mongoose": "^5.4.1",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,8 @@
+const types = {
+    HOST: 'host',
+    SHELTER: 'shelter'
+}
+
+module.exports = {
+    types
+};

--- a/src/resources/animal/animal.model.js
+++ b/src/resources/animal/animal.model.js
@@ -47,4 +47,4 @@ const animalSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-module.exports.Animal = mongoose.model("animal", animalSchema);
+module.exports.Animal = mongoose.model("Animal", animalSchema);

--- a/src/resources/animal/animal.router.js
+++ b/src/resources/animal/animal.router.js
@@ -1,17 +1,18 @@
 const express = require("express");
 const controllers = require("./animal.controllers");
+const { protect } = require('../../utils/auth');
 
 const router = express.Router();
 
 router
   .route("/")
   .get(controllers.getMany)
-  .post(controllers.createOne);
+  .post(protect, controllers.createOne);
 
 router
   .route("/:id")
   .get(controllers.getOneById)
-  .put(controllers.updateOne)
-  .delete(controllers.removeOne);
+  .put(protect, controllers.updateOne)
+  .delete(protect, controllers.removeOne);
 
 module.exports = router;

--- a/src/resources/host/host.model.js
+++ b/src/resources/host/host.model.js
@@ -44,4 +44,4 @@ const hostSchema = new mongoose.Schema(
   { typestamps: true }
 );
 
-module.exports.Host = mongoose.model("host", hostSchema);
+module.exports.Host = mongoose.model("Host", hostSchema);

--- a/src/resources/host/host.model.js
+++ b/src/resources/host/host.model.js
@@ -11,7 +11,6 @@ const hostSchema = new mongoose.Schema(
     shelterId: {
       type: mongoose.SchemaTypes.ObjectId,
       ref: "shelter",
-      required: true
     },
     approved: {
       type: Boolean,

--- a/src/resources/host/host.model.js
+++ b/src/resources/host/host.model.js
@@ -23,6 +23,11 @@ const hostSchema = new mongoose.Schema(
       trim: true,
       maxlength: 70
     },
+    email: {
+      type: String,
+      required: true,
+      unique: true
+    },
     phoneNumber: {
       type: String,
       required: true,

--- a/src/resources/shelter/shelter.model.js
+++ b/src/resources/shelter/shelter.model.js
@@ -14,6 +14,11 @@ const shelterSchema = new mongoose.Schema(
       trim: true,
       maxlength: 70
     },
+    email: {
+      type: String,
+      required: true,
+      unique: true
+    },
     phoneNumber: {
       type: String,
       required: true,

--- a/src/resources/shelter/shelter.model.js
+++ b/src/resources/shelter/shelter.model.js
@@ -29,4 +29,4 @@ const shelterSchema = new mongoose.Schema(
   { typestamps: true }
 );
 
-module.exports.Shelter = mongoose.model("shelter", shelterSchema);
+module.exports.Shelter = mongoose.model("Shelter", shelterSchema);

--- a/src/resources/shelter/shelter.model.js
+++ b/src/resources/shelter/shelter.model.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const bcrypt = require('bcrypt');
 
 const shelterSchema = new mongoose.Schema(
   {
@@ -19,6 +20,11 @@ const shelterSchema = new mongoose.Schema(
       required: true,
       unique: true
     },
+    password: {
+      type: String,
+      required: true,
+      trim: true
+    },
     phoneNumber: {
       type: String,
       required: true,
@@ -33,5 +39,30 @@ const shelterSchema = new mongoose.Schema(
   },
   { typestamps: true }
 );
+
+shelterSchema.pre('save', function(next) {
+  if (!this.isModified('password')) {
+    return next();
+  }
+  bcrypt.hash(this.password, 10, (err, hash) => {
+    if (err) {
+      return next(err);
+    }
+    this.password = hash;
+    next();
+  });
+});
+
+shelterSchema.methods.checkPassword = function(password) {
+  const passwordHash = this.password;
+  return new Promise((resolve, reject) => {
+    bcrypt.compare(password, passwordHash, (err, same) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve(same);
+    });
+  });
+};
 
 module.exports.Shelter = mongoose.model("Shelter", shelterSchema);

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,7 @@ const { connect } = require("./utils/db");
 const animalRouter = require("./resources/animal/animal.router");
 const hostRouter = require("./resources/host/host.router");
 const shelterRouter = require("./resources/shelter/shelter.router");
-const { register } = require('./utils/auth');
+const { register, signin } = require('./utils/auth');
 
 const app = express();
 const PORT = 3000;
@@ -13,6 +13,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use(morgan('dev'));
 
 app.post('/register', register);
+app.post('/signin', signin);
 app.use("/api/hosts", hostRouter);
 app.use("/api/animals", animalRouter);
 app.use("/api/shelters", shelterRouter);

--- a/src/server.js
+++ b/src/server.js
@@ -1,19 +1,20 @@
 const express = require("express");
-const morgan = require('morgan');
+const morgan = require("morgan");
 const { connect } = require("./utils/db");
 const animalRouter = require("./resources/animal/animal.router");
 const hostRouter = require("./resources/host/host.router");
 const shelterRouter = require("./resources/shelter/shelter.router");
-const { register, signin } = require('./utils/auth');
+const { register, signin, protect } = require("./utils/auth");
 
 const app = express();
 const PORT = 3000;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(morgan('dev'));
+app.use(morgan("dev"));
 
-app.post('/register', register);
-app.post('/signin', signin);
+app.post("/register", register);
+app.post("/signin", signin);
+app.use("/api", protect);
 app.use("/api/hosts", hostRouter);
 app.use("/api/animals", animalRouter);
 app.use("/api/shelters", shelterRouter);

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const morgan = require('morgan');
 const { connect } = require("./utils/db");
 const animalRouter = require("./resources/animal/animal.router");
 const hostRouter = require("./resources/host/host.router");
@@ -8,6 +9,7 @@ const app = express();
 const PORT = 3000;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(morgan('dev'));
 
 app.use("/api/hosts", hostRouter);
 app.use("/api/animals", animalRouter);

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const { connect } = require("./utils/db");
 const animalRouter = require("./resources/animal/animal.router");
 const hostRouter = require("./resources/host/host.router");
 const shelterRouter = require("./resources/shelter/shelter.router");
+const { register } = require('./utils/auth');
 
 const app = express();
 const PORT = 3000;
@@ -11,6 +12,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(morgan('dev'));
 
+app.post('/register', register);
 app.use("/api/hosts", hostRouter);
 app.use("/api/animals", animalRouter);
 app.use("/api/shelters", shelterRouter);

--- a/src/server.js
+++ b/src/server.js
@@ -14,10 +14,12 @@ app.use(morgan("dev"));
 
 app.post("/register", register);
 app.post("/signin", signin);
-app.use("/api", protect);
-app.use("/api/hosts", hostRouter);
+// app.use("/api", protect);
+app.use("/api/hosts", protect, hostRouter);
+// app.get('/api/animals', animalRouter);
+// app.get('/api/animals/:id', animalRouter);
 app.use("/api/animals", animalRouter);
-app.use("/api/shelters", shelterRouter);
+app.use("/api/shelters", protect, shelterRouter);
 
 module.exports.start = async () => {
   try {

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,31 @@
+const jwt = require("jsonwebtoken");
+const { Host } = require('../resources/host/host.model');
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecret';
+const { HOST, SHELTER } = require('../config');
+
+const newToken = (user, type) => {
+    return jwt.sign({id: user._id, type }, JWT_SECRET, {expiresIn: '1h'});
+};
+
+const register = async (req, res) => {
+  const { name, address, phoneNumber, email } = req.body;
+  if (!name || !address || !phoneNumber || !email) {
+    return res
+      .status(400)
+      .send({ message: "name, address, phone number, and email required" });
+  }
+
+  try {
+      const host = await Host.create(req.body);
+      const token = newToken(host._id, HOST);
+      return res.status(201).send({ token });
+  } catch (err) {
+      console.error(err);
+      return res.sendStatus(500);
+  }
+};
+
+
+module.exports = {
+    register
+};

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,31 +1,113 @@
 const jwt = require("jsonwebtoken");
-const { Host } = require('../resources/host/host.model');
-const JWT_SECRET = process.env.JWT_SECRET || 'supersecret';
-const { HOST, SHELTER } = require('../config');
+const { Host } = require("../resources/host/host.model");
+const { Shelter } = require("../resources/shelter/shelter.model");
+const JWT_SECRET = process.env.JWT_SECRET || "supersecret";
+const { HOST, SHELTER } = require("../config").types;
 
-const newToken = (user, type) => {
-    return jwt.sign({id: user._id, type }, JWT_SECRET, {expiresIn: '1h'});
+const newToken = (id, type) => {
+  return jwt.sign({ id, type }, JWT_SECRET, { expiresIn: "1h" });
 };
 
 const register = async (req, res) => {
-  const { name, address, phoneNumber, email } = req.body;
-  if (!name || !address || !phoneNumber || !email) {
-    return res
-      .status(400)
-      .send({ message: "name, address, phone number, and email required" });
+  const { name, address, phoneNumber, email, password } = req.body;
+  if (!name || !address || !phoneNumber || !email || !password) {
+    return res.status(400).send({
+      message: "name, address, phone number, email, and password required"
+    });
   }
 
   try {
-      const host = await Host.create(req.body);
-      const token = newToken(host._id, HOST);
-      return res.status(201).send({ token });
+    const host = await Host.create(req.body);
+    const token = newToken(host._id, HOST);
+    return res.status(201).send({ token });
   } catch (err) {
-      console.error(err);
-      return res.sendStatus(500);
+    console.error(err);
+    return res.sendStatus(500);
+  }
+};
+
+const signin = async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(500).send({ message: "email and password required" });
+  }
+  const invalid = { message: "invalid email and password combination" };
+  try {
+    const hostSigninAttempt = await signinHost(email, password);
+    console.log(hostSigninAttempt);
+    if (hostSigninAttempt) {
+      if (hostSigninAttempt.err) {
+        return res.sendStatus(500);
+      }
+      if (!hostSigninAttempt.id) {
+        return res.status(401).send(invalid);
+      }
+      if (hostSigninAttempt.id) {
+        const token = newToken(hostSigninAttempt.id, HOST);
+        return res.status(201).send({ token });
+      }
+    } else {
+      const shelterSigninAttempt = await signinShelter(email, password);
+      console.log(shelterSigninAttempt);
+      if (shelterSigninAttempt) {
+        if (shelterSigninAttempt.err) {
+          return res.sendStatus(500);
+        }
+        if (!shelterSigninAttempt.id) {
+          return res.status(401).send(invalid);
+        }
+        if (shelterSigninAttempt.id) {
+          const token = newToken(shelterSigninAttempt.id, SHELTER);
+          return res.status(201).send({ token });
+        }
+      } else {
+        return res.status(401).send(invalid);
+      }
+    }
+  } catch (err) {}
+};
+
+const signinHost = async (email, password) => {
+  try {
+    const host = await Host.findOne({ email })
+      .select("email password")
+      .exec();
+    if (!host) {
+      return null;
+    }
+    const match = await host.checkPassword(password);
+    if (!match) {
+      return { err: null, id: null };
+    }
+    return { err: null, id: host._id };
+  } catch (err) {
+    console.error(err);
+    return { err };
+  }
+};
+
+const signinShelter = async (email, password) => {
+  try {
+    const shelter = await Shelter.findOne({ email })
+      .select("email password")
+      .exec();
+    if (!shelter) {
+      return null;
+    }
+    const match = await shelter.checkPassword(password);
+    if (!match) {
+      return { err: null, id: null };
+    }
+    return { err: null, id: shelter._id };
+  } catch (err) {
+    console.error(err);
+    return { err };
   }
 };
 
 
+
 module.exports = {
-    register
+  register,
+  signin
 };

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -72,7 +72,10 @@ const signin = async (req, res) => {
         return res.status(401).send(invalid);
       }
     }
-  } catch (err) {}
+  } catch (err) {
+    console.error(err);
+    res.sendStatus(500);
+  }
 };
 
 const signinHost = async (email, password) => {

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 const dbUser = process.env.DBUSER;
 const dbPassword = process.env.DBPASSWORD;
-// const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
-const url = 'mongodb://localhost:27017/RescueForce2';
+const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
+// const url = 'mongodb://localhost:27017/RescueForce2';
 
 module.exports.connect = () => {
   return mongoose.connect(

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 const dbUser = process.env.DBUSER;
 const dbPassword = process.env.DBPASSWORD;
-const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
-
+// const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
+const url = 'mongodb://localhost:27017/RescueForce2';
 
 module.exports.connect = () => {
   return mongoose.connect(

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 const dbUser = process.env.DBUSER;
 const dbPassword = process.env.DBPASSWORD;
 const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
-// const url = 'mongodb://localhost:27017/RescueForce2';
+// const url = 'mongodb://localhost:27017/RescueForce';
 
 module.exports.connect = () => {
   return mongoose.connect(


### PR DESCRIPTION
This is a bit problematic.  Since we don't have a 'users' collection, /src/utils/auth.js currently needs to check both the 'hosts' and 'shelters' collections in order to sign a user in.  This makes for very ugly code and may hurt us in the future.  There is undoubtedly a more elegant way of handling the situation, but we might want to consider revisiting our model.  

Currently, users can register and login.  Users can only register as a new host.  We will have to make a decision about how to register a new shelter.  When a user logs in, they receive a token that identifies them by id and by 'type' as either 'host' or 'shelter'.  

non-logged in users can make get requests to /api/animals and /api/animals/:id, but all other requests are locked down and require a token.

The token must be sent with requests in the Authorization header, with the form 'Bearer ____token___'.  

The Host and Shelter models have been modified to require unique emails.  Email and password is used to log in, so this will lock out any users that we already have in the dev db.  

We will need to configure a JWT_SECRET environment variable.  Currently, there is a default 'supersecret' hardcoded into /src/utils/auth.js.  This will need to be removed soon, but should be ok for now.

There is still work to be done, such as sending better rejection messages.  