### PR TITLE
Privilege filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -638,6 +638,11 @@
         "streamsearch": "0.1.2"
       }
     },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "aws-sdk": "^2.382.0",
     "bcrypt": "^3.0.3",
+    "dotenv": "^6.2.0",
     "express": "^4.16.4",
     "jsonwebtoken": "^8.4.0",
     "mongoose": "^5.4.1",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,19 +4,6 @@ const types = {
   SHELTER: "shelter"
 };
 
-const filters = {
-  defaultUser: {
-
-  },
-  hostUser: {
-
-  },
-  shelterUser: {
-
-  }
-};
-
 module.exports = {
-  filters,
   types
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,5 @@
 const types = {
+  DEFAULT: 'default',
   HOST: "host",
   SHELTER: "shelter"
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,6 +4,19 @@ const types = {
   SHELTER: "shelter"
 };
 
+const filters = {
+  defaultUser: {
+
+  },
+  hostUser: {
+
+  },
+  shelterUser: {
+
+  }
+};
+
 module.exports = {
+  filters,
   types
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
+require("dotenv").config();
 const { start } = require("./server");
 start();

--- a/src/resources/animal/animal.controllers.js
+++ b/src/resources/animal/animal.controllers.js
@@ -1,4 +1,33 @@
 const { crudControllers } = require("../../utils/crud");
 const { Animal } = require("./animal.model");
+const { DEFAULT, HOST, SHELTER } = require("../../config").types;
+const addFilter = require("../../utils/filter");
 
-module.exports = crudControllers(Animal);
+const filters = {
+  viewAnimals: (req, res, next) => {
+    if (req.userType === DEFAULT) {
+      return addFilter({ status: "adoptable" })(req, res, next);
+    } else if (req.userType === HOST) {
+      return addFilter({ status: "need-foster" })(req, res, next);
+    } else if (req.userType === SHELTER) {
+      return addFilter({})(req, res, next);
+    } else {
+      res.sendStatus(500);
+    }
+  },
+  viewAnimal: (req, res, next) => {
+    if (req.userType === DEFAULT) {
+      return addFilter({ status: "adoptable" })(req, res, next);
+    } else if (req.userType === HOST) {
+      return addFilter({
+        $or: [{ status: "need-foster" }, { hostId: req.user._id }]
+      })(req, res, next);
+    } else if (req.userType === SHELTER) {
+      return addFilter({})(req, res, next);
+    } else {
+      res.sendStatus(500);
+    }
+  }
+};
+
+module.exports = { controllers: crudControllers(Animal), filters };

--- a/src/resources/animal/animal.model.js
+++ b/src/resources/animal/animal.model.js
@@ -22,7 +22,7 @@ const animalSchema = new mongoose.Schema(
     status: {
       type: String,
       required: true,
-      enum: ["adoptable", "foster-only"],
+      enum: ["adoptable", "foster-only", "need-foster"],
       default: "foster-only"
     },
     species: {

--- a/src/resources/animal/animal.router.js
+++ b/src/resources/animal/animal.router.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const controllers = require("./animal.controllers");
-const { protect } = require("../../utils/auth");
 const upload = require("../../utils/imageUpload");
 
 const router = express.Router();
@@ -8,18 +7,18 @@ const router = express.Router();
 router
   .route("/")
   .get(controllers.getMany)
-  .post(protect, controllers.createOne);
+  .post(controllers.createOne);
 
 router
   .route("/:id")
   .get(controllers.getOneById)
-  .put(protect, controllers.updateOne)
-  .delete(protect, controllers.removeOne);
+  .put(controllers.updateOne)
+  .delete(controllers.removeOne);
 
 router
   .route("/:id/photos")
   .get(controllers.getPhotos)
-  .post(protect, upload.array("image", 1), controllers.addPhoto)
-  .delete(protect, controllers.removePhoto);
+  .post(upload.array("image", 1), controllers.addPhoto)
+  .delete(controllers.removePhoto);
 
 module.exports = router;

--- a/src/resources/animal/animal.router.js
+++ b/src/resources/animal/animal.router.js
@@ -1,19 +1,20 @@
 const express = require("express");
-const controllers = require("./animal.controllers");
+const { controllers, filters } = require("./animal.controllers");
 const upload = require("../../utils/imageUpload");
+const { hostAndShelterOnly, shelterOnly } = require("../../utils/auth");
 
 const router = express.Router();
 
 router
   .route("/")
-  .get(controllers.getMany)
-  .post(controllers.createOne);
+  .get(filters.viewAnimals, controllers.getMany)
+  .post(shelterOnly, controllers.createOne);
 
 router
   .route("/:id")
-  .get(controllers.getOneById)
-  .put(controllers.updateOne)
-  .delete(controllers.removeOne);
+  .get(filters.viewAnimal, controllers.getOne)
+  .put(hostAndShelterOnly, controllers.updateOne)
+  .delete(shelterOnly, controllers.removeOne);
 
 router
   .route("/:id/photos")

--- a/src/resources/host/host.controllers.js
+++ b/src/resources/host/host.controllers.js
@@ -1,4 +1,18 @@
 const { crudControllers } = require("../../utils/crud");
 const { Host } = require("./host.model");
+const { HOST, SHELTER } = require("../../config").types;
+const addFilter = require("../../utils/filter");
 
-module.exports = crudControllers(Host);
+const filters = {
+  viewHost: (req, res, next) => {
+    if (req.userType === HOST) {
+      return addFilter({ _id: req.user._id })(req, res, next);
+    } else if (req.userType === SHELTER) {
+      return addFilter({})(req, res, next);
+    } else {
+      res.sendStatus(500);
+    }
+  }
+};
+
+module.exports = { controllers: crudControllers(Host), filters };

--- a/src/resources/host/host.router.js
+++ b/src/resources/host/host.router.js
@@ -1,6 +1,7 @@
 const express = require("express");
-const controllers = require("./host.controllers");
+const { controllers, filters } = require("./host.controllers");
 const upload = require("../../utils/imageUpload");
+const { hostAndShelterOnly, shelterOnly } = require("../../utils/auth");
 
 const router = express.Router();
 
@@ -11,14 +12,14 @@ router
 
 router
   .route("/:id")
-  .get(controllers.getOneById)
-  .put(controllers.updateOne)
-  .delete(controllers.removeOne);
+  .get(filters.viewHost, controllers.getOne)
+  .put(filters.viewHost, controllers.updateOne)
+  .delete(shelterOnly, controllers.removeOne);
 
 router
   .route("/:id/photos")
   .get(controllers.getPhotos)
-  .post(upload.array("image", 1), controllers.addPhoto)
-  .delete(controllers.removePhoto);
+  .post(hostAndShelterOnly, upload.array("image", 1), controllers.addPhoto)
+  .delete(hostAndShelterOnly, controllers.removePhoto);
 
 module.exports = router;

--- a/src/resources/shelter/shelter.router.js
+++ b/src/resources/shelter/shelter.router.js
@@ -1,24 +1,25 @@
 const express = require("express");
 const controllers = require("./shelter.controllers");
 const upload = require("../../utils/imageUpload");
+const { shelterOnly } = require("../../utils/auth");
 
 const router = express.Router();
 
 router
   .route("/")
   .get(controllers.getMany)
-  .post(controllers.createOne);
+  .post(shelterOnly, controllers.createOne);
 
 router
   .route("/:id")
-  .get(controllers.getOneById)
-  .put(controllers.updateOne)
-  .delete(controllers.removeOne);
+  .get(controllers.getOne)
+  .put(shelterOnly, controllers.updateOne)
+  .delete(shelterOnly, controllers.removeOne);
 
 router
   .route("/:id/photos")
   .get(controllers.getPhotos)
-  .post(upload.array("image", 1), controllers.addPhoto)
-  .delete(controllers.removePhoto);
+  .post(shelterOnly, upload.array("image", 1), controllers.addPhoto)
+  .delete(shelterOnly, controllers.removePhoto);
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,7 @@ const { connect } = require("./utils/db");
 const animalRouter = require("./resources/animal/animal.router");
 const hostRouter = require("./resources/host/host.router");
 const shelterRouter = require("./resources/shelter/shelter.router");
-const { register, signin, protect } = require("./utils/auth");
+const { register, signin, classify, hostAndShelterOnly } = require("./utils/auth");
 
 const app = express();
 const PORT = 3000;
@@ -14,9 +14,10 @@ app.use(morgan("dev"));
 
 app.post("/register", register);
 app.post("/signin", signin);
-app.use("/api/hosts", protect, hostRouter);
+app.use("/api", classify);
+app.use("/api/hosts", hostAndShelterOnly, hostRouter);
 app.use("/api/animals", animalRouter);
-app.use("/api/shelters", protect, shelterRouter);
+app.use("/api/shelters", shelterRouter);
 
 module.exports.start = async () => {
   try {

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -120,7 +120,7 @@ const classify = async (req, res, next) => {
   const bearer = req.headers.authorization;
   if (!bearer || !bearer.startsWith("Bearer ")) {
     // return res.sendStatus(401);
-    res.userType = DEFAULT;
+    req.userType = DEFAULT;
     return next();
   }
   const token = bearer.split(" ")[1].trim();
@@ -133,7 +133,7 @@ const classify = async (req, res, next) => {
         .exec();
       if (!host) {
         // return res.sendStatus(401);
-        res.userType = DEFAULT;
+        req.userType = DEFAULT;
         return next();
       }
       req.user = host;
@@ -146,7 +146,7 @@ const classify = async (req, res, next) => {
         .exec();
       if (!shelter) {
         // return res.sendStatus(401);
-        res.userType = DEFAULT;
+        req.userType = DEFAULT;
         return next();
       }
       req.user = shelter;

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -2,7 +2,7 @@ const jwt = require("jsonwebtoken");
 const { Host } = require("../resources/host/host.model");
 const { Shelter } = require("../resources/shelter/shelter.model");
 const JWT_SECRET = process.env.JWT_SECRET || "supersecret";
-const { HOST, SHELTER } = require("../config").types;
+const { DEFAULT, HOST, SHELTER } = require("../config").types;
 
 const newToken = (id, type) => {
   return jwt.sign({ id, type }, JWT_SECRET, { expiresIn: "4h" });
@@ -116,10 +116,12 @@ const signinShelter = async (email, password) => {
   }
 };
 
-const protect = async (req, res, next) => {
+const classify = async (req, res, next) => {
   const bearer = req.headers.authorization;
   if (!bearer || !bearer.startsWith("Bearer ")) {
-    return res.sendStatus(401);
+    // return res.sendStatus(401);
+    res.userType = DEFAULT;
+    return next();
   }
   const token = bearer.split(" ")[1].trim();
   try {
@@ -130,7 +132,9 @@ const protect = async (req, res, next) => {
         .lean()
         .exec();
       if (!host) {
-        return res.sendStatus(401);
+        // return res.sendStatus(401);
+        res.userType = DEFAULT;
+        return next();
       }
       req.user = host;
       req.userType = HOST;
@@ -141,7 +145,9 @@ const protect = async (req, res, next) => {
         .lean()
         .exec();
       if (!shelter) {
-        return res.sendStatus(401);
+        // return res.sendStatus(401);
+        res.userType = DEFAULT;
+        return next();
       }
       req.user = shelter;
       req.userType = SHELTER;
@@ -152,8 +158,24 @@ const protect = async (req, res, next) => {
   }
 };
 
+const hostAndShelterOnly = (req, res, next) => {
+  if (!(req.userType === HOST || req.userType === SHELTER)) {
+    return res.sendStatus(401);
+  }
+  next();
+};
+
+const shelterOnly = (req, res, next) => {
+  if (!req.userType === SHELTER) {
+    return res.sendStatus(401);
+  }
+  next();
+};
+
 module.exports = {
   register,
   signin,
-  protect
+  classify,
+  hostAndShelterOnly,
+  shelterOnly
 };

--- a/src/utils/crud.js
+++ b/src/utils/crud.js
@@ -1,7 +1,7 @@
-const getOneById = model => async (req, res) => {
+const getOne = model => async (req, res) => {
   try {
     const doc = await model
-      .findById(req.params.id)
+      .find({...req.filter, _id: req.params.id})
       .lean()
       .exec();
 
@@ -39,7 +39,7 @@ const getMany = model => async (req, res) => {
     let docs;
     if (!req.query.name) {
       docs = await model
-        .find({})
+        .find(req.filter)
         .lean()
         .exec();
     } else {
@@ -164,7 +164,7 @@ module.exports.crudControllers = model => ({
   removeOne: removeOne(model),
   updateOne: updateOne(model),
   getMany: getMany(model),
-  getOneById: getOneById(model),
+  getOne: getOne(model),
   getOneByName: getOneByName(model),
   createOne: createOne(model),
   getPhotos: getPhotos(model),

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 const dbUser = process.env.DBUSER;
 const dbPassword = process.env.DBPASSWORD;
-const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
-// const url = 'mongodb://localhost:27017/RescueForce';
+// const url = `mongodb://${dbUser}:${dbPassword}@ds241723.mlab.com:41723/rescueforcedb`
+const url = 'mongodb://localhost:27017/RescueForce';
 
 module.exports.connect = () => {
   return mongoose.connect(

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,0 +1,6 @@
+const filter = filter => (req, res, next) => {
+    req.filter = filter;
+    next();
+}
+
+module.exports = filter;


### PR DESCRIPTION
This adds finer filtering for what users are able to access.  All filtering is still all-or-nothing, meaning that if a host is able to update an animal, then they can update all information about the animal.  In the future, we will want some fields to only be alterable by the shelter, such as the animal's host id.  

The improvement that this push brings comes in cases where we want an automatically reduced list.  For example, when unauthenticated users make a get request to see all animals, they now only see those who are eligible for adoption.  When a host makes the same request, they only see animals that are in need of foster homes.